### PR TITLE
Add missing extend module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,15 +2,16 @@
   "name": "voxeling-engine",
   "description": "make games with voxel.js",
   "dependencies": {
-    "gl-matrix": "2.3.1",
-    "ws": "0.7.2",
-    "browserify": "11.0.1",
     "beefy": "2.1.5",
-    "voxel-raycast": "0.2.1",
-    "sillyname": "0.0.3",
+    "browserify": "11.0.1",
+    "extend": "^3.0.0",
+    "gl-matrix": "2.3.1",
     "hat": "0.0.3",
     "inherits": "~2.0.1",
-    "perlin": "~1.0.0"
+    "perlin": "~1.0.0",
+    "sillyname": "0.0.3",
+    "voxel-raycast": "0.2.1",
+    "ws": "0.7.2"
   },
   "scripts": {
     "test": "node test.js"


### PR DESCRIPTION
When attempting to run the server after following the instructions in the readme (using node v5.3.0 on OS X 10.11.2), I get this error about a missing module:

$ node server.js 
module.js:328
    throw err;
    ^

Error: Cannot find module 'extend'
    at Function.Module._resolveFilename (module.js:326:15)
    at Function.Module._load (module.js:277:25)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (voxel/voxeling/lib/generator.js:1:76)
    at Module._compile (module.js:398:26)
    at Object.Module._extensions..js (module.js:405:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)

Installing the module with `npm install --save extend` fixed this error (note that I let npm update `package.json` which explains why it is sorted – alternatively it could be edited by hand to make a smaller diff if needed). 
